### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,10 @@
-# README
+## groups_usersテーブル
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ has_many :groups, through: :groups_users
 ###Association
 - belongs_to :user
 - has_many :groups
-
+aaa
 
 ## groups_usersテーブル
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -1,10 +1,40 @@
-## groups_usersテーブル
+# Chatspace DB設計
+##Usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|email|string|null: false|
+|password|string|null: false|
+###Association
+- has_many :groups_users
+- has_many  :users,  through:  :groups_users
 
+
+##groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|groupname|string|null: false|
+|user_id|integer|null: false, foreign_key: true|
+###Association
+has_many :groups_users
+has_many :groups, through: :groups_users
+
+
+##messegesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|text|text|null: false|
+|image|text|null: false|
+###Association
+- belongs_to :user
+- has_many :groups
+
+
+## groups_usersテーブル
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
-
 ### Association
 - belongs_to :group
 - belongs_to :user


### PR DESCRIPTION
#what
グループテーブルととユーザーテーブルの中間テーブルにあたるgroups_usersテーブルの作成。

#why
ユーザーとグループの関係が 多対多となり、アソシエーションを定義するには中間テーブルが必要なため。